### PR TITLE
Change to use vcsrepo module and parameterize "revision" variable

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,4 @@ license 'GPLv3'
 summary 'Puppet PhpMyAdmin Module'
 description 'Module to install PhpMyAdmin using puppet.'
 project_page 'https://github.com/leoc/puppet-phpmyadmin/'
+dependency "puppetlabs/vcsrepo", ">=0.1.2"

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ puppet module install puppetlabs/nginx
 
 ```
   class { 'phpmyadmin':
-    path => "/srv/phpmyadmin",
-    user => "www-data",
+    path    => "/srv/phpmyadmin",
+    user    => "www-data",
+    version => "RELEASE_4_0_9",
     servers => [
       {
         desc => "local",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ web server (e.g. puppet-nginx)
 ## Suggested Preparation
 
 This module is as simple as possible. You should be able to choose
-your own php installation. This is my own, which works quite find, as
+your own php installation. This is my own, which works quite fine, as
 I find:
 
 1. First I install the
@@ -48,10 +48,10 @@ puppet module install puppetlabs/nginx
 
 ```
   class { 'phpmyadmin':
-    path    => "/srv/phpmyadmin",
-    user    => "www-data",
-    version => "RELEASE_4_0_9",
-    servers => [
+    path     => "/srv/phpmyadmin",
+    user     => "www-data",
+    revision => "RELEASE_4_0_9",
+    servers  => [
       {
         desc => "local",
         host => "127.0.0.1",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,9 +9,10 @@
 # === Examples
 #
 #  class { 'phpmyadmin':
-#    path => "/srv/phpmyadmin",
-#    user => "www-data",
-#    servers => [
+#    path     => "/srv/phpmyadmin",
+#    user     => "www-data",
+#    revision => "RELEASE_4_0_9",
+#    servers  => [
 #      {
 #        desc => "local",
 #        host => "127.0.0.1",
@@ -37,6 +38,7 @@
 class phpmyadmin (
   $path = "/srv/phpmyadmin",
   $user = "www-data",
+  $revision = 'origin/STABLE',
   $servers = []
 ) {
   vcsrepo { $path:
@@ -44,7 +46,7 @@ class phpmyadmin (
     provider => 'git',
     source   => 'https://github.com/phpmyadmin/phpmyadmin.git',
     user     => $user,
-    revision => 'origin/STABLE',
+    revision => $revision,
   }
   ->
   file { "phpmyadmin-conf":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,35 +39,17 @@ class phpmyadmin (
   $user = "www-data",
   $servers = []
 ) {
-  if !defined(Package['git']) {
-    package { 'git': ensure => present; }
+  vcsrepo { $path:
+    ensure   => present,
+    provider => 'git',
+    source   => 'https://github.com/phpmyadmin/phpmyadmin.git',
+    user     => $user,
+    revision => 'origin/STABLE',
   }
-
-  file { $path:
-    ensure => "directory",
-    owner => $user,
-    require => Package['git'],
-  }
-
-  exec { "phpmyadmin-checkout":
-    path => "/bin:/usr/bin",
-    creates => "$path/.git",
-    command => "git clone https://github.com/phpmyadmin/phpmyadmin.git ${path}",
-    require => File[$path],
-    user => $user,
-  }
-
-  exec { "phpmyadmin-upgrade":
-    path => "/bin:/usr/bin",
-    command => "bash -c 'cd ${path}; git fetch; git checkout origin/STABLE'",
-    require => Exec["phpmyadmin-checkout"],
-    user => $user,
-  }
-
+  ->
   file { "phpmyadmin-conf":
     path => "$path/config.inc.php",
     content => template("phpmyadmin/config.inc.php.erb"),
     owner => $user,
-    require => Exec["phpmyadmin-upgrade"],
   }
 } # Class:: phpmyadmin


### PR DESCRIPTION
This changes the phpmyadmin class to use the "vcsrepo" Puppet module instead of calling git directly. This has several advantages:
- vcsrepo won't do an unnecessary "git fetch" if it's already at the right revision, since it uses "ls-remote" first. This can save a lot of bandwidth on subsequent runs.
- vcsrepo automatically requires the "git" package.
- vcsrepo automatically creates the destination directory if it doesn't exist.

I also parameterized the "revision" variable so users can specify different versions of PHPMyAdmin and aren't limited to the latest stable version.
