### PR TITLE
Minor update to Modulefile: we actually need vcsrepo v0.2.0 

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,4 +6,4 @@ license 'GPLv3'
 summary 'Puppet PhpMyAdmin Module'
 description 'Module to install PhpMyAdmin using puppet.'
 project_page 'https://github.com/leoc/puppet-phpmyadmin/'
-dependency "puppetlabs/vcsrepo", ">=0.1.2"
+dependency "puppetlabs/vcsrepo", ">=0.2.0"


### PR DESCRIPTION
In PR #1, I said "vcsrepo automatically requires the "git" package", but that feature was introduced in an commit that wasn't in version 0.1.2 (the latest version at the time). Fortunately, the vcsrepo guys [just released version 0.2.0](http://forge.puppetlabs.com/puppetlabs/vcsrepo/0.2.0), which does have that commit. This updates Modulefile to reflect that dependency.
