### PR TITLE
Adding Depth param to support shallow checkout

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,8 @@ class phpmyadmin (
   $path = "/srv/phpmyadmin",
   $user = "www-data",
   $revision = 'origin/STABLE',
-  $servers = []
+  $servers = [],
+  $depth = 0,
 ) {
   vcsrepo { $path:
     ensure   => present,
@@ -47,6 +48,7 @@ class phpmyadmin (
     source   => 'https://github.com/phpmyadmin/phpmyadmin.git',
     user     => $user,
     revision => $revision,
+    depth    => $depth,
   }
   ->
   file { "phpmyadmin-conf":


### PR DESCRIPTION
This will enable users to checkout phpmyadmin using a shallow commit avoiding downloading (GB's) of all revision history of the phpmyadmin project.

The patch is based on master branch. Not sure why other commits are listed in this pull request.
