### PR TITLE
Allow any server option, random blowfish and recursive path creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,9 +43,21 @@ class phpmyadmin (
   $servers  = [],
 ) {
 
+  exec { "PMA install dir ${path}":
+    user      => 'root',
+    command   => "mkdir -p ${path}",
+    unless    => "test -d ${path}",
+    path      => ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin'],
+    logoutput => 'on_failure',
+  }
+
+  ->
+
   file { $path:
     ensure => directory,
     owner  => $user,
+    group  => $user,
+    mode   => '0755',
   }
 
   ->

--- a/templates/config.inc.php.erb
+++ b/templates/config.inc.php.erb
@@ -1,11 +1,12 @@
 <?php
-  $cfg['blowfish_secret'] = 'ba17c1ec07d65003';
+  $cfg['blowfish_secret'] = '<%= (1..50).map{(rand(86)+40).chr}.join.gsub(/\\/,'\&\&') %>';
 
   $i=0;
 
-  <% @servers.each do |server| %>
+  <% @servers.each do |server| -%>
   $i++;
-  $cfg['Servers'][$i]['auth_type'] = 'cookie';
-  $cfg['Servers'][$i]['host']      = '<%= server["host"] %>';
+    <% server.each do |property, value| -%>
+  $cfg['Servers'][$i]['<%= property %>'] = '<%= value %>';
+    <% end -%>
   <% end %>
 ?>


### PR DESCRIPTION
Proposed improvements:
- Allow **any** server option through the parameter `servers` (array of hashes, keys being the server property and values the properties values).
- Generate a random `blowfish_secret` instead of harcoding one in the `config.inc.php.erb` template.
- Create recursively the provided installation path `path` (currently the provision fails if any of the involved folders does not exist).
